### PR TITLE
Change from /run to /kd (kaptain deploy) not because /run is a system…

### DIFF
--- a/.github/bin/run-tests
+++ b/.github/bin/run-tests
@@ -23,17 +23,17 @@ KUBE_MINOR_MIN=32
 KUBE_MINOR_MAX=35
 
 # Patch levels per distro (UBI lags behind by one point release)
-PATCH_alpine_3_23=4
-PATCH_trixie_slim=4
-PATCH_ubi_9_minimal=3
-PATCH_ubuntu_24_04_lts=4
+PATCH_alpine_3_23=6
+PATCH_trixie_slim=6
+PATCH_ubi_9_minimal=5
+PATCH_ubuntu_24_04_lts=6
 
 # Distros - must match Dockerfile template suffixes
 DISTROS="alpine-3-23 trixie-slim ubi-9-minimal ubuntu-24-04-lts"
 
 # Default mode: single quick validation
 DEFAULT_DISTRO="trixie-slim"
-DEFAULT_TAG="1.35.4"
+DEFAULT_TAG="1.35.6"
 
 # Counters
 FAILED=0
@@ -186,19 +186,19 @@ run_tests_in_container() {
   local label="$2"
   local bats_args=""
   if [[ -n "${ONE_BATS:-}" ]]; then
-    bats_args="/run/test/${ONE_BATS}.bats"
+    bats_args="/kd/test/${ONE_BATS}.bats"
     label="${label} [${ONE_BATS}]"
   fi
 
   echo "Running tests: ${label}"
 
   if docker run --rm \
-    -v "${SRC_DIR}/scripts:/run/bin:ro" \
-    -v "${SRC_DIR}/test:/run/test:ro" \
-    -v "${SRC_DIR}/test/fixtures/manifests:/run/fixtures/manifests:ro" \
-    -v "${SRC_DIR}/test/fixtures/secrets:/run/fixtures/secrets:ro" \
-    -v "${SRC_DIR}/test/fixtures/templates:/run/fixtures/templates:ro" \
-    -e "PATH=/run/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    -v "${SRC_DIR}/scripts:/kd/bin:ro" \
+    -v "${SRC_DIR}/test:/kd/test:ro" \
+    -v "${SRC_DIR}/test/fixtures/manifests:/kd/fixtures/manifests:ro" \
+    -v "${SRC_DIR}/test/fixtures/secrets:/kd/fixtures/secrets:ro" \
+    -v "${SRC_DIR}/test/fixtures/templates:/kd/fixtures/templates:ro" \
+    -e "PATH=/kd/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
     "${image_id}" \
     run-bats ${bats_args}; then
     echo "  PASSED: ${label}"

--- a/src/scripts/apply-manifests
+++ b/src/scripts/apply-manifests
@@ -6,7 +6,7 @@
 # Output captured to audit log for inspection if needed.
 set -euo pipefail
 
-base="${RUN_BASE_PATH:-/run}"
+base="${RUN_BASE_PATH:-/kd}"
 manifests_dir="${base}/work/manifests"
 audit_dir="${base}/work/audit"
 apply_log="${audit_dir}/apply.log"

--- a/src/scripts/assemble-secrets
+++ b/src/scripts/assemble-secrets
@@ -5,7 +5,7 @@
 # Assemble secrets: substitute tokens into template files.
 set -euo pipefail
 
-base="${RUN_BASE_PATH:-/run}"
+base="${RUN_BASE_PATH:-/kd}"
 work="${base}/work"
 manifests_dir="${work}/manifests"
 decrypted_dir="${work}/decrypted"

--- a/src/scripts/decrypt-secret
+++ b/src/scripts/decrypt-secret
@@ -17,7 +17,7 @@ fi
 relative_path="$1"
 suffix="$2"
 
-base="${RUN_BASE_PATH:-/run}"
+base="${RUN_BASE_PATH:-/kd}"
 secrets_dir="${base}/secrets"
 decrypted_dir="${base}/work/decrypted"
 

--- a/src/scripts/decrypt-secrets
+++ b/src/scripts/decrypt-secrets
@@ -3,7 +3,7 @@
 # Copyright (c) 2025-2026 Kaptain contributors (Fred Cooke)
 #
 # Decrypt all secret files from secrets dir to decrypted dir.
-# Handles nested paths: /run/secrets/foo/bar.age → decrypted/foo/bar
+# Handles nested paths: /kd/secrets/foo/bar.age → decrypted/foo/bar
 # Token substitution uses relative path: ${foo/bar} (shell style)
 #
 # Expects all files to use the same encryption suffix (.age recommended).
@@ -11,7 +11,7 @@
 # but reports them clearly at the end.
 set -euo pipefail
 
-base="${RUN_BASE_PATH:-/run}"
+base="${RUN_BASE_PATH:-/kd}"
 secrets_dir="${base}/secrets"
 decrypted_dir="${base}/work/decrypted"
 

--- a/src/scripts/deploy
+++ b/src/scripts/deploy
@@ -120,7 +120,7 @@ if ! validate_token_styles; then
 fi
 
 # Path setup - RUN_BASE_PATH allows tests to override
-base="${RUN_BASE_PATH:-/run}"
+base="${RUN_BASE_PATH:-/kd}"
 work="${base}/work"
 decrypted="${work}/decrypted"
 audit="${work}/audit"

--- a/src/scripts/k
+++ b/src/scripts/k
@@ -7,7 +7,7 @@
 # Logs each invocation to the audit directory before executing.
 set -euo pipefail
 
-AUDIT_DIR="/run/work/audit/kubectl"
+AUDIT_DIR="/kd/work/audit/kubectl"
 
 # Identify the calling script or shell
 caller="$(ps -o comm= -p ${PPID} 2>/dev/null || true)"

--- a/src/scripts/notify-oci-images-changed
+++ b/src/scripts/notify-oci-images-changed
@@ -6,7 +6,7 @@
 # Groups changes by registry for readable output.
 set -euo pipefail
 
-base="${RUN_BASE_PATH:-/run}"
+base="${RUN_BASE_PATH:-/kd}"
 output_dir="${base}/work/oci-images"
 before="${output_dir}/oci-images-before-sorted"
 after="${output_dir}/oci-images-after-sorted"

--- a/src/scripts/oci-images
+++ b/src/scripts/oci-images
@@ -13,7 +13,7 @@ fi
 
 label="$1"
 
-base="${RUN_BASE_PATH:-/run}"
+base="${RUN_BASE_PATH:-/kd}"
 output_dir="${base}/work/oci-images"
 unsorted="${output_dir}/oci-images-${label}-unsorted"
 sorted="${output_dir}/oci-images-${label}-sorted"

--- a/src/scripts/prepare-manifests
+++ b/src/scripts/prepare-manifests
@@ -5,7 +5,7 @@
 # Prepare phase: copy manifests to writable work directory.
 set -euo pipefail
 
-base="${RUN_BASE_PATH:-/run}"
+base="${RUN_BASE_PATH:-/kd}"
 source_dir="${base}/manifests"
 work_dir="${base}/work/manifests"
 

--- a/src/scripts/validate-manifests
+++ b/src/scripts/validate-manifests
@@ -6,7 +6,7 @@
 # Validates each file individually, capturing output to audit directory.
 set -euo pipefail
 
-base="${RUN_BASE_PATH:-/run}"
+base="${RUN_BASE_PATH:-/kd}"
 manifests_dir="${base}/work/manifests"
 audit_dir="${base}/work/audit/validation"
 

--- a/src/test/docker-templates/run-bats.bash
+++ b/src/test/docker-templates/run-bats.bash
@@ -9,5 +9,5 @@ set -euo pipefail
 if [[ $# -gt 0 ]]; then
   exec bats "$@"
 else
-  exec bats /run/test/*.bats
+  exec bats /kd/test/*.bats
 fi

--- a/src/test/host-side/entrypoint-scripts.bats
+++ b/src/test/host-side/entrypoint-scripts.bats
@@ -22,27 +22,27 @@ setup() {
 # Helper to run script as container entrypoint with scripts mounted
 run_as_entrypoint() {
   docker run --rm \
-    -v "${SCRIPTS_DIR}:/run/bin:ro" \
-    -e "PATH=/run/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    -v "${SCRIPTS_DIR}:/kd/bin:ro" \
+    -e "PATH=/kd/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
     "$@"
 }
 
 # --- notify-*-echo scripts ---
 
 @test "notify-info-echo produces output as entrypoint" {
-  run run_as_entrypoint "${TEST_IMAGE}" /run/bin/notify-info-echo "entrypoint test"
+  run run_as_entrypoint "${TEST_IMAGE}" /kd/bin/notify-info-echo "entrypoint test"
   [ "$status" -eq 0 ]
   [[ "$output" == *"entrypoint test"* ]]
 }
 
 @test "notify-error-echo produces output as entrypoint" {
-  run run_as_entrypoint "${TEST_IMAGE}" /run/bin/notify-error-echo "error test"
+  run run_as_entrypoint "${TEST_IMAGE}" /kd/bin/notify-error-echo "error test"
   [ "$status" -eq 0 ]
   [[ "$output" == *"error test"* ]]
 }
 
 @test "notify-warning-echo produces output as entrypoint" {
-  run run_as_entrypoint "${TEST_IMAGE}" /run/bin/notify-warning-echo "warning test"
+  run run_as_entrypoint "${TEST_IMAGE}" /kd/bin/notify-warning-echo "warning test"
   [ "$status" -eq 0 ]
   [[ "$output" == *"warning test"* ]]
 }
@@ -50,19 +50,19 @@ run_as_entrypoint() {
 # --- notify-* dispatcher scripts ---
 
 @test "notify-info produces output as entrypoint" {
-  run run_as_entrypoint "${TEST_IMAGE}" /run/bin/notify-info "info dispatch test"
+  run run_as_entrypoint "${TEST_IMAGE}" /kd/bin/notify-info "info dispatch test"
   [ "$status" -eq 0 ]
   [[ "$output" == *"info dispatch test"* ]]
 }
 
 @test "notify-error produces output as entrypoint" {
-  run run_as_entrypoint "${TEST_IMAGE}" /run/bin/notify-error "error dispatch test"
+  run run_as_entrypoint "${TEST_IMAGE}" /kd/bin/notify-error "error dispatch test"
   [ "$status" -eq 0 ]
   [[ "$output" == *"error dispatch test"* ]]
 }
 
 @test "notify-warning produces output as entrypoint" {
-  run run_as_entrypoint "${TEST_IMAGE}" /run/bin/notify-warning "warning dispatch test"
+  run run_as_entrypoint "${TEST_IMAGE}" /kd/bin/notify-warning "warning dispatch test"
   [ "$status" -eq 0 ]
   [[ "$output" == *"warning dispatch test"* ]]
 }
@@ -70,7 +70,7 @@ run_as_entrypoint() {
 # --- alert-echo script ---
 
 @test "alert-echo produces output as entrypoint" {
-  run run_as_entrypoint "${TEST_IMAGE}" /run/bin/alert-echo "alert test"
+  run run_as_entrypoint "${TEST_IMAGE}" /kd/bin/alert-echo "alert test"
   [ "$status" -eq 0 ]
   [[ "$output" == *"alert test"* ]]
 }
@@ -78,7 +78,7 @@ run_as_entrypoint() {
 # --- alert dispatcher script ---
 
 @test "alert produces output as entrypoint" {
-  run run_as_entrypoint "${TEST_IMAGE}" /run/bin/alert "alert dispatch test"
+  run run_as_entrypoint "${TEST_IMAGE}" /kd/bin/alert "alert dispatch test"
   [ "$status" -eq 0 ]
   [[ "$output" == *"alert dispatch test"* ]]
 }
@@ -86,7 +86,7 @@ run_as_entrypoint() {
 # --- log script ---
 
 @test "log produces output as entrypoint" {
-  run run_as_entrypoint "${TEST_IMAGE}" /run/bin/log "log test"
+  run run_as_entrypoint "${TEST_IMAGE}" /kd/bin/log "log test"
   [ "$status" -eq 0 ]
   [[ "$output" == *"log test"* ]]
 }
@@ -94,17 +94,17 @@ run_as_entrypoint() {
 # --- validate-* scripts (expected failures with visible output) ---
 
 @test "validate-environment shows errors when env missing" {
-  run run_as_entrypoint "${TEST_IMAGE}" /run/bin/validate-environment
+  run run_as_entrypoint "${TEST_IMAGE}" /kd/bin/validate-environment
   [ "$status" -ne 0 ]
   [[ "$output" == *"must be set"* ]]
 }
 
 @test "validate-container shows errors when mounts missing" {
   run docker run --rm \
-    -v "${SCRIPTS_DIR}:/run/bin:ro" \
-    -e "PATH=/run/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    -v "${SCRIPTS_DIR}:/kd/bin:ro" \
+    -e "PATH=/kd/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
     -e "MOUNT_BASE_PATH=/nonexistent" \
-    "${TEST_IMAGE}" /run/bin/validate-container
+    "${TEST_IMAGE}" /kd/bin/validate-container
   [ "$status" -ne 0 ]
   [[ "$output" == *"not found"* ]]
 }

--- a/src/test/k.bats
+++ b/src/test/k.bats
@@ -3,7 +3,7 @@
 # Copyright (c) 2025-2026 Kaptain contributors (Fred Cooke)
 #
 # Tests for the k (namespace-locked kubectl wrapper) script.
-# k hardcodes /run/work/audit/kubectl for audit logs.
+# k hardcodes /kd/work/audit/kubectl for audit logs.
 # k uses ENVIRONMENT which is set by the environment build process.
 
 load test_helper
@@ -11,13 +11,13 @@ load test_helper
 setup() {
   setup_test_dirs
   install_mock_kubectl
-  # k writes to /run/work/audit/kubectl (hardcoded)
-  mkdir -p /run/work/audit/kubectl
+  # k writes to /kd/work/audit/kubectl (hardcoded)
+  mkdir -p /kd/work/audit/kubectl
   export ENVIRONMENT="test-namespace"
 }
 
 teardown() {
-  rm -rf /run/work/audit/kubectl/*
+  rm -rf /kd/work/audit/kubectl/*
   teardown_test_dirs
 }
 
@@ -32,16 +32,16 @@ teardown() {
 @test "k creates audit log entry" {
   k get deployments
   local count
-  count=$(ls /run/work/audit/kubectl/ | wc -l)
+  count=$(ls /kd/work/audit/kubectl/ | wc -l)
   [ "${count}" -ge 1 ]
 }
 
 @test "k logs the full command in audit file" {
   k apply -f /tmp/test.yaml
   local audit_file
-  audit_file=$(ls -t /run/work/audit/kubectl/ | head -1)
+  audit_file=$(ls -t /kd/work/audit/kubectl/ | head -1)
   local content
-  content=$(</run/work/audit/kubectl/"${audit_file}")
+  content=$(</kd/work/audit/kubectl/"${audit_file}")
   [[ "${content}" == *"kubectl -n test-namespace apply -f /tmp/test.yaml"* ]]
 }
 

--- a/src/test/notify-echo.bats
+++ b/src/test/notify-echo.bats
@@ -6,7 +6,7 @@
 # These are the built-in echo providers that output to stdout/stderr.
 # Must work even when PPID=0 (container init process) or ps fails.
 
-SCRIPTS_DIR="/run/bin"
+SCRIPTS_DIR="/kd/bin"
 
 @test "notify-info-echo produces output with message" {
   run "${SCRIPTS_DIR}/notify-info-echo" "test message"
@@ -173,25 +173,25 @@ SCRIPTS_DIR="/run/bin"
 @test "notify-info-echo works when run as container entrypoint" {
   # When run as PID 1, PPID=0, grandparent lookup fails
   # Simulate by calling from minimal process chain where grandparent is PID 1
-  run bash -c 'exec bash -c "exec /run/bin/notify-info-echo \"entrypoint test\""'
+  run bash -c 'exec bash -c "exec /kd/bin/notify-info-echo \"entrypoint test\""'
   [ "$status" -eq 0 ]
   [[ "$output" == *"entrypoint test"* ]]
 }
 
 @test "notify-error-echo works when run as container entrypoint" {
-  run bash -c 'exec bash -c "exec /run/bin/notify-error-echo \"entrypoint error\""'
+  run bash -c 'exec bash -c "exec /kd/bin/notify-error-echo \"entrypoint error\""'
   [ "$status" -eq 0 ]
   [[ "$output" == *"entrypoint error"* ]]
 }
 
 @test "notify-info works when run as container entrypoint" {
-  run bash -c 'exec bash -c "exec /run/bin/notify-info \"dispatcher test\""'
+  run bash -c 'exec bash -c "exec /kd/bin/notify-info \"dispatcher test\""'
   [ "$status" -eq 0 ]
   [[ "$output" == *"dispatcher test"* ]]
 }
 
 @test "notify-error works when run as container entrypoint" {
-  run bash -c 'exec bash -c "exec /run/bin/notify-error \"dispatcher error\""'
+  run bash -c 'exec bash -c "exec /kd/bin/notify-error \"dispatcher error\""'
   [ "$status" -eq 0 ]
   [[ "$output" == *"dispatcher error"* ]]
 }
@@ -202,7 +202,7 @@ SCRIPTS_DIR="/run/bin"
 @test "validate-environment produces error output when env vars missing" {
   # Unset required vars - validation SHOULD fail with visible error messages
   unset DEPLOY_MODE ENVIRONMENT VERSION TOKEN_DELIMITER_STYLE TOKEN_NAME_STYLE
-  run bash -c 'exec /run/bin/validate-environment'
+  run bash -c 'exec /kd/bin/validate-environment'
   # Should fail (exit 44) but with visible output
   [ "$status" -ne 0 ]
   [[ "$output" == *"must be set"* ]]
@@ -211,7 +211,7 @@ SCRIPTS_DIR="/run/bin"
 @test "validate-container produces error output when mounts missing" {
   # No mounts configured - validation SHOULD fail with visible error messages
   export MOUNT_BASE_PATH="/nonexistent"
-  run bash -c 'exec /run/bin/validate-container'
+  run bash -c 'exec /kd/bin/validate-container'
   # Should fail but with visible output
   [ "$status" -ne 0 ]
   [[ "$output" == *"not found"* ]]

--- a/src/test/test_helper.bash
+++ b/src/test/test_helper.bash
@@ -4,8 +4,8 @@
 #
 # Common test helper for BATS tests.
 
-SCRIPTS_DIR="/run/bin"
-FIXTURES_DIR="/run/fixtures"
+SCRIPTS_DIR="/kd/bin"
+FIXTURES_DIR="/kd/fixtures"
 
 setup_test_dirs() {
   # Create base directories for RUN_BASE_PATH structure


### PR DESCRIPTION
… dir and has lock/ in it but rather because kube auto mounts service account tokens in /run/secrets/ and the decrypt script rejects all the unknown files. If not this thorough it would have worked. But thorough is best. :-)